### PR TITLE
Support additional event names

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ github.com/mutility/coverpkg/internal/...:  37.88%  150 of 396
 
 As an action, coverpkg will store coverage information in [git notes](https://git-scm.com/docs/git-notes). This requires an extra pull and push during the default `push` support, and an extra pull during the `pull_request` support. Pull requests can be commented on to reveal their state of coverage, and if base information is available, the changes. See `comment` and `token` in *Options* below.
 
-We suggest a workflow similar to the following. In particular, coverpkg supports running on push and pull_request, and it requires go and a copy of your code checked out to what you want to test. For pull requests, it requires a token such as the `${{ github.token }}` to create and/or update comments. For pushes, it requires the ability to push back to your repository, so avoid specifying `persist-credentials: false` on your `actions/checkout@v2`. Without push support, the pull_request comment can only report the current coverage.
+We suggest a workflow similar to the following. In particular, coverpkg supports running on `push` and `pull_request`, and it requires go and a copy of your code checked out to what you want to test. For pull requests, it requires a token such as the `${{ github.token }}` to create and/or update comments. For pushes, it requires the ability to push back to your repository, so avoid specifying `persist-credentials: false` on your `actions/checkout@v2`. Without push support, the pull_request comment can only report the current coverage.
 
 ```yaml
 name: 'Coverage'
@@ -53,6 +53,10 @@ jobs:
         token: ${{ github.token }}
         comment: update
 ```
+
+### Events
+
+The coverpkg action primarily supports `push` and `pull_request` events. In addition, it supports `pull_request_target` as an alias to `pull_request`, and `workflow_dispatch` and `repository_dispatch` act like `push`. All other events log a debug message and succeed so you don't absolutely have to filter when you invoke coverpkg.
 
 ### Options
 

--- a/cmd/coverpkg-gha/main.go
+++ b/cmd/coverpkg-gha/main.go
@@ -194,10 +194,47 @@ retrieved.`,
 
 		Commands: []*cli.Command{
 			{
-				Name:   "push",
-				Before: requireEventPath,
-				Action: runPush,
-				Usage:  "calculate and save code coverage for the head commit",
+				Name: "nop",
+				Aliases: []string{
+					"schedule",
+					"check_run",
+					"check_suite",
+					"create",
+					"delete",
+					"deployment",
+					"deployment_status",
+					"fork",
+					"gollum",
+					"issue_comment",
+					"issues",
+					"label",
+					"milestone",
+					"page_build",
+					"project",
+					"project_card",
+					"project_column",
+					"public",
+					"pull_request_review",
+					"pull_request_review_comment",
+					"registry_package",
+					"release",
+					"status",
+					"watch",
+					"workflow_run",
+				},
+				Usage: "Does nothing; exits without an error for unsupported GitHub Action events.",
+				Action: func(c *cli.Context) error {
+					gha, _ := cfg.GitHubContext(c)
+					gha.Debug("Unsupported event")
+					return nil
+				},
+			},
+			{
+				Name:    "push",
+				Aliases: []string{"workflow_dispatch", "repository_dispatch"},
+				Before:  requireEventPath,
+				Action:  runPush,
+				Usage:   "calculate and save code coverage for the head commit",
 				Description: "Calculates, saves, and pushes code coverage information for the head commit.\n" +
 					"Requires the following:\n\n" +
 					"  * The desired commit has been checked out\n" +
@@ -214,10 +251,11 @@ retrieved.`,
 				},
 			},
 			{
-				Name:   "pull_request",
-				Before: requireEventPath,
-				Action: runPR,
-				Usage:  "calculate and display code coverage (and change) for the head commit",
+				Name:    "pull_request",
+				Aliases: []string{"pull_request_target"},
+				Before:  requireEventPath,
+				Action:  runPR,
+				Usage:   "calculate and display code coverage (and change) for the head commit",
 
 				Flags: []cli.Flag{
 					stringVar(&cfg.APIToken, "api-token", "specify the token used for commenting on pull requests", "INPUT_TOKEN"),


### PR DESCRIPTION
Consider dispatch as aliases to push, pull_request_target as an alias to
pull_request. Log and exit with success for all others.