### PR TITLE
Remote path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,10 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - run: go run ./cmd/coverpkg-gha ${{ github.event_name }}
+    - run: go build ./cmd/coverpkg-gha
+      shell: bash
+      working-directory: ${{ github.action_path }}
+    - run: go run ${{ github.action_path }}/coverpkg-gha ${{ github.event_name }}
       shell: bash
       env:
         INPUT_EXCLUDES: ${{ inputs.excludes }}

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
     - run: go build ./cmd/coverpkg-gha
       shell: bash
       working-directory: ${{ github.action_path }}
-    - run: go run ${{ github.action_path }}/coverpkg-gha ${{ github.event_name }}
+    - run: ${{ github.action_path }}/coverpkg-gha ${{ github.event_name }}
       shell: bash
       env:
         INPUT_EXCLUDES: ${{ inputs.excludes }}


### PR DESCRIPTION
Fix use of go run so coverpkg works in other repos. While we could set up a dance to invoke go run in `${{ github.action_path }}` and change to `${{ githup.workspace }}` when it runs tests, it seems simpler and safer to just build it then invoke it.